### PR TITLE
 Enable left and right swipePanel

### DIFF
--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -4080,6 +4080,16 @@
                     else {
                         direction = 'to-left';
                     }
+                    // Enable left and right swipePanel
+                    if(side==='both'){
+						if ($('.panel.active').length > 0) {
+								side = $('.panel.active').hasClass('panel-left') ? 'left' : 'right';
+						}
+						else {
+							side = direction == "to-right" ? "left":"right";
+						}
+						panel = $('.panel.panel-' + side);
+						}
         
                     if (
                         side === 'left' &&


### PR DESCRIPTION
With this "myApp.params.swipePanel" can be set to "left", "right" or "both"
It is working great and to avoid any conflict and overlapping add the below CSS and custom JS:

```
//CSS
.panel.active{
    display:block;
}
.with-panel-left-reveal .panel-right, .with-panel-right-reveal .panel-left{
    display:none !important;
}
```

```
//JS
$$('.panel-left').on('opened', function () {
    $$('.panel-right').hide();
    $$('.panel-left').show();
});
$$('.panel-right').on('opened', function () {
    $$('.panel-left').hide();
    $$('.panel-right').show();
});
```
